### PR TITLE
Two changes to "center()", to make it work more like Jeet's center()

### DIFF
--- a/s-grid-functions.styl
+++ b/s-grid-functions.styl
@@ -47,15 +47,22 @@ cell(i = 1, cols = columns, align = '', g = gutter)
 cell-offset(i = 1, cols = columns, g = gutter)
     margin-left: s('calc(100% * %s + (%s / 2))', i / cols, rem-calc(g)) !important
 
-center(value)
-    margin-left auto
-    margin-right auto
-    width 100%
-    u = unit(value)
-    if (u is 'rem')
-        max-width unit(value, u)
-    else
-        max-width rem-calc(value)
+center(value, pad = auto)
+  margin-left auto
+  margin-right auto
+  width 100%
+  u = unit(value)
+  if (u is 'rem' or u is '%')
+    max-width unit(value, u)
+  else
+    max-width rem-calc(value)
+  p = unit(pad)
+  if (p is 'rem' or p is '%')
+    padding-left  unit(pad, p)
+    padding-right  unit(pad, p)
+  else
+    padding-left rem-calc(pad)
+    padding-right rem-calc(pad)
 
 stack()
     cell(1, 1)

--- a/s-grid-functions.styl
+++ b/s-grid-functions.styl
@@ -47,7 +47,7 @@ cell(i = 1, cols = columns, align = '', g = gutter)
 cell-offset(i = 1, cols = columns, g = gutter)
     margin-left: s('calc(100% * %s + (%s / 2))', i / cols, rem-calc(g)) !important
 
-center(value, pad = auto)
+center(value, pad = null)
   margin-left auto
   margin-right auto
   width 100%
@@ -56,13 +56,16 @@ center(value, pad = auto)
     max-width unit(value, u)
   else
     max-width rem-calc(value)
-  p = unit(pad)
-  if (p is 'rem' or p is '%')
-    padding-left  unit(pad, p)
-    padding-right  unit(pad, p)
+  if (pad is null)
+    return
   else
-    padding-left rem-calc(pad)
-    padding-right rem-calc(pad)
+    p = unit(pad)
+    if (p is 'rem' or p is '%')
+      padding-left  unit(pad, p)
+      padding-right  unit(pad, p)
+    else
+      padding-left rem-calc(pad)
+      padding-right rem-calc(pad)
 
 stack()
     cell(1, 1)

--- a/s-grid-functions.styl
+++ b/s-grid-functions.styl
@@ -48,24 +48,24 @@ cell-offset(i = 1, cols = columns, g = gutter)
     margin-left: s('calc(100% * %s + (%s / 2))', i / cols, rem-calc(g)) !important
 
 center(value, pad = null)
-  margin-left auto
-  margin-right auto
-  width 100%
-  u = unit(value)
-  if (u is 'rem' or u is '%')
-    max-width unit(value, u)
-  else
-    max-width rem-calc(value)
-  if (pad is null)
-    return
-  else
-    p = unit(pad)
-    if (p is 'rem' or p is '%')
-      padding-left  unit(pad, p)
-      padding-right  unit(pad, p)
+    margin-left auto
+    margin-right auto
+    width 100%
+    u = unit(value)
+    if (u is 'rem' or u is '%')
+      max-width unit(value, u)
     else
-      padding-left rem-calc(pad)
-      padding-right rem-calc(pad)
+      max-width rem-calc(value)
+    if (pad is null)
+      return
+    else
+      p = unit(pad)
+      if (p is 'rem' or p is '%')
+        padding-left  unit(pad, p)
+        padding-right  unit(pad, p)
+      else
+        padding-left rem-calc(pad)
+        padding-right rem-calc(pad)
 
 stack()
     cell(1, 1)

--- a/s-grid-functions.styl
+++ b/s-grid-functions.styl
@@ -53,19 +53,19 @@ center(value, pad = null)
     width 100%
     u = unit(value)
     if (u is 'rem' or u is '%')
-      max-width unit(value, u)
+        max-width unit(value, u)
     else
-      max-width rem-calc(value)
+        max-width rem-calc(value)
     if (pad is null)
-      return
+        return
     else
-      p = unit(pad)
-      if (p is 'rem' or p is '%')
-        padding-left  unit(pad, p)
-        padding-right  unit(pad, p)
-      else
-        padding-left rem-calc(pad)
-        padding-right rem-calc(pad)
+        p = unit(pad)
+        if (p is 'rem' or p is '%')
+          padding-left  unit(pad, p)
+          padding-right  unit(pad, p)
+        else
+          padding-left rem-calc(pad)
+          padding-right rem-calc(pad)
 
 stack()
     cell(1, 1)


### PR DESCRIPTION
(This is actually my first Pull Request, so please let me know if I did this wrong!)

I'm really enjoying s-grid! Previously, I've used Jeet. One thing I liked about Jeet was passing percentages into the "center()" function, both for max-width and side padding. I made a slight modification to s-grid's center() function to allow passing percentages and optional padding as a second variable. Otherwise the function works as before, so should not conflict with existing code.

I tested for and corrected several cases where it broke. It's possible I haven't considered every failure case. Let me know if I have missed something obvious. 😄 

Thanks for making s-grid. Hope this small change is helpful.

**Original Commit Message:**

Two changes to "center()", to make it work more like Jeet's center() function:
1. Add check for % as value, eg. "center(75%)" for responsive container width.
2. Add 2nd optional variable, "pad", to specify left and right padding. eg. "center(100%, 5%)" for reponsive container padding.
   Not completely sure I'm using the unit() function correctly, but it works in my build environment.
